### PR TITLE
Fix a unit conversion issue with generation latency

### DIFF
--- a/ecologits/__init__.py
+++ b/ecologits/__init__.py
@@ -1,4 +1,4 @@
 from .ecologits import EcoLogits
 
 __all__ = ["EcoLogits"]
-__version__ = "0.1.3"
+__version__ = "0.1.4"

--- a/ecologits/impacts/llm.py
+++ b/ecologits/impacts/llm.py
@@ -1,3 +1,4 @@
+import json
 from math import ceil
 from typing import Optional
 
@@ -136,7 +137,7 @@ def server_energy(
     Returns:
         The energy consumption of the server (GPUs are not included).
     """
-    return generation_latency * server_power * (gpu_required_count / server_gpu_count)
+    return (generation_latency / 3600) * server_power * (gpu_required_count / server_gpu_count)
 
 
 @dag.asset
@@ -422,6 +423,7 @@ def compute_llm_impacts(
         if_electricity_mix_adpe=if_electricity_mix_adpe,
         if_electricity_mix_pe=if_electricity_mix_pe
     )
+    print(json.dumps(results, indent=4))
     energy = Energy(value=results["request_energy"])
     gwp_usage = GWP(value=results["request_usage_gwp"])
     adpe_usage = ADPe(value=results["request_usage_adpe"])
@@ -446,3 +448,14 @@ def compute_llm_impacts(
             pe=pe_embodied
         )
     )
+
+
+if __name__ == '__main__':
+    impacts = compute_llm_impacts(
+        model_active_parameter_count=45,
+        model_total_parameter_count=45,
+        output_token_count=250,
+        request_latency=10000,
+    )
+    print('Energy:', impacts.energy.value)
+

--- a/ecologits/impacts/llm.py
+++ b/ecologits/impacts/llm.py
@@ -1,4 +1,3 @@
-import json
 from math import ceil
 from typing import Optional
 
@@ -423,7 +422,6 @@ def compute_llm_impacts(
         if_electricity_mix_adpe=if_electricity_mix_adpe,
         if_electricity_mix_pe=if_electricity_mix_pe
     )
-    print(json.dumps(results, indent=4))
     energy = Energy(value=results["request_energy"])
     gwp_usage = GWP(value=results["request_usage_gwp"])
     adpe_usage = ADPe(value=results["request_usage_adpe"])
@@ -448,14 +446,3 @@ def compute_llm_impacts(
             pe=pe_embodied
         )
     )
-
-
-if __name__ == '__main__':
-    impacts = compute_llm_impacts(
-        model_active_parameter_count=45,
-        model_total_parameter_count=45,
-        output_token_count=250,
-        request_latency=10000,
-    )
-    print('Energy:', impacts.energy.value)
-

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "ecologits"
-version = "0.1.3"
+version = "0.1.4"
 description = "EcoLogits tracks and estimates the energy consumption and environmental impacts of using generative AI models through APIs."
 authors = [
     "GenAI Impact",


### PR DESCRIPTION
Generation latency is in seconds by default and must be converted in hours to compute server energy.