### PR TITLE
Fix LiteLLM async+stream doc

### DIFF
--- a/docs/tutorial/providers/litellm.md
+++ b/docs/tutorial/providers/litellm.md
@@ -111,7 +111,8 @@ Integrating EcoLogits with your applications does not alter the standard outputs
             model="gpt-3.5-turbo",
             messages=[
                 {"role": "user", "content": "Tell me a funny joke!"}
-            ]
+            ], 
+            stream=True
         )
         
         async for chunk in stream:


### PR DESCRIPTION
Missing `stream=True` in async+stream documentation

Closes https://github.com/genai-impact/ecologits/issues/124 