### PR TITLE
Added mean property to RangeValue

### DIFF
--- a/ecologits/utils/range_value.py
+++ b/ecologits/utils/range_value.py
@@ -15,6 +15,10 @@ class RangeValue(BaseModel):
     min: Union[float, int]
     max: Union[float, int]
 
+    @property
+    def mean(self) -> float:
+        return (self.min + self.max) / 2
+
     @model_validator(mode="after")
     def check_order(self) -> Self:
         if self.min > self.max:


### PR DESCRIPTION
When calculating the impact of an LLM it is often useful to have an estimate on the various metrics. However, oftentimes the result will be a `RangeValue` which provides a min and a max value.

This PR adds a `mean` property to the `RangeValue` class, simplifying the access to the mean value of the range.