### PR TITLE
Add custom models in `ModelRepository`

### DIFF
--- a/ecologits/model_repository.py
+++ b/ecologits/model_repository.py
@@ -83,7 +83,7 @@ class ModelRepository:
     Repository of models
     """
 
-    def __init__(self, models: list[Model], aliases: Optional[list[Alias]] = None) -> None:
+    def __init__(self, models: Optional[list[Model]] = None, aliases: Optional[list[Alias]] = None) -> None:
         self.__models: dict[tuple[str, str], Model] = {}
         if models is not None:
             for m in models:

--- a/ecologits/model_repository.py
+++ b/ecologits/model_repository.py
@@ -84,20 +84,26 @@ class ModelRepository:
         self.__models: dict[tuple[str, str], Model] = {}
         if models is not None:
             for m in models:
-                key = m.provider.value, m.name
-                if key in self.__models:
-                    raise ValueError(f"duplicated models with: {key}")
-                self.__models[key] = m
+                self.add_model(m)
 
         if aliases is not None:
             for a in aliases:
-                model_key = a.provider.value, a.alias
-                if model_key not in self.__models:
-                    raise ValueError(f"model alias not found: {model_key}")
-                alias_key = a.provider.value, a.name
-                model = self.__models[model_key].model_copy()
-                model.name = a.name
-                self.__models[alias_key] = model
+                self.add_alias(a)
+
+    def add_model(self, model: Model) -> None:
+        key = model.provider.value, model.name
+        if key in self.__models:
+            raise ValueError(f"duplicated models with: {key}")
+        self.__models[key] = model
+
+    def add_alias(self, alias: Alias) -> None:
+        model_key = alias.provider.value, alias.alias
+        if model_key not in self.__models:
+            raise ValueError(f"model alias not found: {model_key}")
+        alias_key = alias.provider.value, alias.name
+        model = self.__models[model_key].model_copy()
+        model.name = alias.name
+        self.__models[alias_key] = model
 
     def find_model(self, provider: str, model_name: str) -> Optional[Model]:
         return self.__models.get((provider, model_name))

--- a/tests/test_model_repository.py
+++ b/tests/test_model_repository.py
@@ -1,5 +1,10 @@
 from ecologits.model_repository import ModelRepository
 
+def test_create_empty_repository():
+    models = ModelRepository()
+    assert isinstance(models, ModelRepository)
+    assert not models.list_models()
+
 
 def test_create_model_repository_default():
     models = ModelRepository.from_json()
@@ -23,3 +28,17 @@ def test_ambiguous_names():
     assert models.find_model(provider="openai", model_name="gpt-4-turbo").name == "gpt-4-turbo"
     assert models.find_model(provider="openai", model_name="gpt-4o").name == "gpt-4o"
     assert models.find_model(provider="openai", model_name="gpt-35-turbo").name == "gpt-35-turbo"
+
+
+def test_add_custom_model():
+    models = ModelRepository()
+    custom_model_data = {
+        "provider": "openai",
+        "name": "gpt-4.1-2025-04-14",
+        "architecture": {
+            "type": "moe", 
+            "parameters": 1000
+        }
+    }
+    models.add_model(custom_model_data)
+    assert models.find_model("openai", "gpt-4.1-2025-04-14") is not None    


### PR DESCRIPTION
Answers to #150. 

In this branch, one can add custom models and/or aliases in a `ModelRepository`. For examples, one could do

```python
from ecologits import EcoLogits
from ecologits.model_repository import models, Model, Providers, Architecture, ArchitectureTypes
from openai import OpenAI

# ADD CUSTOM `gpt-4.1-2025-04-14` model
guesstimate = 1000
provider = Providers.openai
name = "gpt-4.1-2025-04-14"
architecture = Architecture(
    type=ArchitectureTypes.MOE, 
    parameters=guesstimate
)
new_model = Model(
    provider=provider, 
    name=name, 
    architecture=architecture
)
models.add_model(new_model)

# USE ECOLOGITS
EcoLogits.init(providers="openai")
client = OpenAI()
response = client.chat.completions.create(
    model="gpt-4.1-2025-04-14",
    messages=[
        {"role": "user", "content": "Tell me a funny joke!"}
    ]
)
print(f"Energy consumption: {response.impacts.energy.value} kWh")
print(f"GHG emissions: {response.impacts.gwp.value} kgCO2eq")


```