### PR TITLE
Update initialization methods for `EcoLogits`

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ from ecologits import EcoLogits
 from openai import OpenAI
 
 # Initialize EcoLogits
-EcoLogits.init()
+EcoLogits.init(providers=["openai"])
 
 client = OpenAI(api_key="<OPENAI_API_KEY>")
 
@@ -46,8 +46,8 @@ response = client.chat.completions.create(
 )
 
 # Get estimated environmental impacts of the inference
-print(f"Energy consumption: {response.impacts.energy.value} kWh")
-print(f"GHG emissions: {response.impacts.gwp.value} kgCO2eq")
+print(f"Energy consumption: {response.impacts.energy.value.mean} kWh")
+print(f"GHG emissions: {response.impacts.gwp.value.mean} kgCO2eq")
 ```
 
 See package documentation on [EcoLogits](https://ecologits.ai/)

--- a/docs/index.md
+++ b/docs/index.md
@@ -70,7 +70,7 @@ Below are simple examples demonstrating how to use LLM models with **EcoLogits**
     from openai import OpenAI
 
     # Initialize EcoLogits
-    EcoLogits.init()
+    EcoLogits.init(provider=["openai"])
 
     client = OpenAI(api_key="<OPENAI_API_KEY>")
 
@@ -109,7 +109,7 @@ Below are simple examples demonstrating how to use LLM models with **EcoLogits**
     from anthropic import Anthropic
     
     # Initialize EcoLogits
-    EcoLogits.init()
+    EcoLogits.init(provider=["anthropic"])
     
     client = Anthropic(api_key="<ANTHROPIC_API_KEY>")
     
@@ -147,7 +147,7 @@ Below are simple examples demonstrating how to use LLM models with **EcoLogits**
     from huggingface_hub import InferenceClient
     
     # Initialize EcoLogits
-    EcoLogits.init()
+    EcoLogits.init(provider=["huggingface_hub"])
     
     client = InferenceClient(model="meta-llama/Meta-Llama-3.1-8B")
     response = client.chat_completion( # (1)!

--- a/docs/tutorial/index.md
+++ b/docs/tutorial/index.md
@@ -45,28 +45,13 @@ It achieves this by **patching the Python client libraries**, ensuring that each
 
 ## Initialization of EcoLogits
 
-To use EcoLogits in your projects, you will need to initialize the client tracers that are used internally to intercept and enrich responses. The default initialization will use default parameters and enable tracking of all available providers. To change that behaviour, read along on how to configure EcoLogits.
+To use EcoLogits in your projects, you will need to initialize the client tracers that are used internally to intercept and enrich responses.
 
 ```python
 from ecologits import EcoLogits
 
-# Default initialization method
-EcoLogits.init()
-```
-
-
-### Configure providers
-
-You can select which provider to enable with EcoLogits using the `providers` parameter.
-
-!!! info "Default behavior is to enable all available providers."
-
-```python title="Select a providers to enable"
-from ecologits import EcoLogits
-
-# Examples on how to enable one or multiple providers
-EcoLogits.init(providers="openai")
-EcoLogits.init(providers=["anthropic", "mistralai"])
+# Example for OpenAI and Anthropic
+EcoLogits.init(providers=["openai", "anthropic"])
 ```
 
 ??? warning "Disabling a provider at runtime is not supported"
@@ -88,5 +73,5 @@ Electricity mixes for each geographic zone are sourced from the [ADEME Base Empr
 from ecologits import EcoLogits
 
 # Select the electricity mix of France
-EcoLogits.init(electricity_mix_zone="FRA")
+EcoLogits.init(providers=[...], electricity_mix_zone="FRA")
 ```

--- a/docs/tutorial/providers/anthropic.md
+++ b/docs/tutorial/providers/anthropic.md
@@ -34,7 +34,7 @@ Integrating EcoLogits with your applications does not alter the standard outputs
     from ecologits import EcoLogits
     
     # Initialize EcoLogits
-    EcoLogits.init()
+    EcoLogits.init(providers=["anthropic"])
     
     client = Anthropic(api_key="<ANTHROPIC_API_KEY>")
     
@@ -56,7 +56,7 @@ Integrating EcoLogits with your applications does not alter the standard outputs
     from ecologits import EcoLogits
     
     # Initialize EcoLogits
-    EcoLogits.init()
+    EcoLogits.init(providers=["anthropic"])
     
     client = AsyncAnthropic(api_key="<ANTHROPIC_API_KEY>")
     
@@ -86,7 +86,7 @@ Integrating EcoLogits with your applications does not alter the standard outputs
     from ecologits import EcoLogits
     
     # Initialize EcoLogits
-    EcoLogits.init()
+    EcoLogits.init(providers=["anthropic"])
     
     client = Anthropic(api_key="<ANTHROPIC_API_KEY>")
     
@@ -109,7 +109,7 @@ Integrating EcoLogits with your applications does not alter the standard outputs
     from ecologits import EcoLogits
     
     # Initialize EcoLogits
-    EcoLogits.init()
+    EcoLogits.init(providers=["anthropic"])
     
     client = AsyncAnthropic(api_key="<ANTHROPIC_API_KEY>")
     

--- a/docs/tutorial/providers/cohere.md
+++ b/docs/tutorial/providers/cohere.md
@@ -35,7 +35,7 @@ Integrating EcoLogits with your applications does not alter the standard outputs
     from ecologits import EcoLogits
     
     # Initialize EcoLogits
-    EcoLogits.EcoLogits.init(providers=["cohere"])
+    EcoLogits.init(providers=["cohere"])
     
     client = Client(api_key="<COHERE_API_KEY>")
     
@@ -56,7 +56,7 @@ Integrating EcoLogits with your applications does not alter the standard outputs
     from ecologits import EcoLogits
     
     # Initialize EcoLogits
-    EcoLogits.EcoLogits.init(providers=["cohere"])
+    EcoLogits.init(providers=["cohere"])
     
     client = AsyncClient(api_key="<COHERE_API_KEY>")
     
@@ -84,7 +84,7 @@ Integrating EcoLogits with your applications does not alter the standard outputs
     from ecologits import EcoLogits
     
     # Initialize EcoLogits
-    EcoLogits.EcoLogits.init(providers=["cohere"])
+    EcoLogits.init(providers=["cohere"])
     
     client = Client(api_key="<COHERE_API_KEY>")
     
@@ -107,7 +107,7 @@ Integrating EcoLogits with your applications does not alter the standard outputs
     from ecologits import EcoLogits
     
     # Initialize EcoLogits
-    EcoLogits.EcoLogits.init(providers=["cohere"])
+    EcoLogits.init(providers=["cohere"])
     
     client = AsyncClient(api_key="<COHERE_API_KEY>")
     

--- a/docs/tutorial/providers/cohere.md
+++ b/docs/tutorial/providers/cohere.md
@@ -35,7 +35,7 @@ Integrating EcoLogits with your applications does not alter the standard outputs
     from ecologits import EcoLogits
     
     # Initialize EcoLogits
-    EcoLogits.init()
+    EcoLogits.EcoLogits.init(providers=["cohere"])
     
     client = Client(api_key="<COHERE_API_KEY>")
     
@@ -56,7 +56,7 @@ Integrating EcoLogits with your applications does not alter the standard outputs
     from ecologits import EcoLogits
     
     # Initialize EcoLogits
-    EcoLogits.init()
+    EcoLogits.EcoLogits.init(providers=["cohere"])
     
     client = AsyncClient(api_key="<COHERE_API_KEY>")
     
@@ -84,7 +84,7 @@ Integrating EcoLogits with your applications does not alter the standard outputs
     from ecologits import EcoLogits
     
     # Initialize EcoLogits
-    EcoLogits.init()
+    EcoLogits.EcoLogits.init(providers=["cohere"])
     
     client = Client(api_key="<COHERE_API_KEY>")
     
@@ -107,7 +107,7 @@ Integrating EcoLogits with your applications does not alter the standard outputs
     from ecologits import EcoLogits
     
     # Initialize EcoLogits
-    EcoLogits.init()
+    EcoLogits.EcoLogits.init(providers=["cohere"])
     
     client = AsyncClient(api_key="<COHERE_API_KEY>")
     

--- a/docs/tutorial/providers/google.md
+++ b/docs/tutorial/providers/google.md
@@ -36,7 +36,7 @@ Integrating EcoLogits with your applications does not alter the standard outputs
     import google.generativeai as genai
     
     # Initialize EcoLogits
-    EcoLogits.init()
+    EcoLogits.init(providers=["google"])
 
     # Ask something to Google Gemini
     genai.configure(api_key="<GOOGLE_API_KEY>")
@@ -55,7 +55,7 @@ Integrating EcoLogits with your applications does not alter the standard outputs
     import google.generativeai as genai
     
     # Initialize EcoLogits
-    EcoLogits.init()
+    EcoLogits.init(providers=["google"])
 
     # Ask something to Google Gemini in async mode
     async def main() -> None:
@@ -82,7 +82,7 @@ Integrating EcoLogits with your applications does not alter the standard outputs
     import google.generativeai as genai
 
     # Initialize EcoLogits
-    EcoLogits.init()
+    EcoLogits.init(providers=["google"])
 
     # Ask something to Google Gemini in streaming mode
     genai.configure(api_key="<GOOGLE_API_KEY>")
@@ -105,7 +105,7 @@ Integrating EcoLogits with your applications does not alter the standard outputs
     import google.generativeai as genai
 
     # Initialize EcoLogits
-    EcoLogits.init()
+    EcoLogits.init(providers=["google"])
 
     # Ask something to Google Gemini in streaming and async mode
     async def main() -> None:

--- a/docs/tutorial/providers/huggingface_hub.md
+++ b/docs/tutorial/providers/huggingface_hub.md
@@ -35,7 +35,7 @@ Integrating EcoLogits with your applications does not alter the standard outputs
     from huggingface_hub import InferenceClient
     
     # Initialize EcoLogits
-    EcoLogits.init()
+    EcoLogits.init(providers=["huggingface_hub"])
     
     client = InferenceClient(model="meta-llama/Meta-Llama-3.1-8B")
     response = client.chat_completion(
@@ -55,7 +55,7 @@ Integrating EcoLogits with your applications does not alter the standard outputs
     from huggingface_hub import AsyncInferenceClient
     
     # Initialize EcoLogits
-    EcoLogits.init()
+    EcoLogits.init(providers=["huggingface_hub"])
     
     client = AsyncInferenceClient(model="meta-llama/Meta-Llama-3.1-8B")
     
@@ -84,7 +84,7 @@ Integrating EcoLogits with your applications does not alter the standard outputs
     from huggingface_hub import InferenceClient
     
     # Initialize EcoLogits
-    EcoLogits.init()
+    EcoLogits.init(providers=["huggingface_hub"])
     
     client = InferenceClient(model="meta-llama/Meta-Llama-3.1-8B")
     stream = client.chat_completion(
@@ -106,7 +106,7 @@ Integrating EcoLogits with your applications does not alter the standard outputs
     from huggingface_hub import AsyncInferenceClient
     
     # Initialize EcoLogits
-    EcoLogits.init()
+    EcoLogits.init(providers=["huggingface_hub"])
     
     client = AsyncInferenceClient(model="meta-llama/Meta-Llama-3.1-8B")
     

--- a/docs/tutorial/providers/litellm.md
+++ b/docs/tutorial/providers/litellm.md
@@ -36,7 +36,7 @@ Integrating EcoLogits with your applications does not alter the standard outputs
     import litellm
     
     # Initialize EcoLogits
-    EcoLogits.init()
+    EcoLogits.init(providers=["litellm"])
     
     response = litellm.completion(
         model="gpt-4o-2024-05-13",
@@ -55,7 +55,7 @@ Integrating EcoLogits with your applications does not alter the standard outputs
     from ecologits import EcoLogits
     
     # Initialize EcoLogits
-    EcoLogits.init()
+    EcoLogits.init(providers=["litellm"])
     
     async def main() -> None:
         response = await litellm.acompletion(
@@ -83,7 +83,7 @@ Integrating EcoLogits with your applications does not alter the standard outputs
     import litellm
     
     # Initialize EcoLogits
-    EcoLogits.init()
+    EcoLogits.init(providers=["litellm"])
     
     stream = litellm.completion(
         model="gpt-3.5-turbo",
@@ -104,7 +104,7 @@ Integrating EcoLogits with your applications does not alter the standard outputs
     from ecologits import EcoLogits
     
     # Initialize EcoLogits
-    EcoLogits.init()
+    EcoLogits.init(providers=["litellm"])
     
     async def main() -> None:
         stream = await litellm.acompletion(

--- a/docs/tutorial/providers/mistralai.md
+++ b/docs/tutorial/providers/mistralai.md
@@ -41,7 +41,7 @@ Integrating EcoLogits with your applications does not alter the standard outputs
     from mistralai import Mistral
     
     # Initialize EcoLogits
-    EcoLogits.init()
+    EcoLogits.init(providers=["mistralai"])
     
     client = Mistral(api_key="<MISTRAL_API_KEY>")
 
@@ -66,7 +66,7 @@ Integrating EcoLogits with your applications does not alter the standard outputs
     from mistralai import Mistral
     
     # Initialize EcoLogits
-    EcoLogits.init()
+    EcoLogits.init(providers=["mistralai"])
     
     client = Mistral(api_key="<MISTRAL_API_KEY>")
     
@@ -99,7 +99,7 @@ Integrating EcoLogits with your applications does not alter the standard outputs
     from mistralai import Mistral
     
     # Initialize EcoLogits
-    EcoLogits.init()
+    EcoLogits.init(providers=["mistralai"])
     
     client = Mistral(api_key="<MISTRAL_API_KEY>")
     
@@ -126,7 +126,7 @@ Integrating EcoLogits with your applications does not alter the standard outputs
     from mistralai import Mistral
     
     # Initialize EcoLogits
-    EcoLogits.init()
+    EcoLogits.init(providers=["mistralai"])
     
     client = Mistral(api_key="<MISTRAL_API_KEY>")
     

--- a/docs/tutorial/providers/openai.md
+++ b/docs/tutorial/providers/openai.md
@@ -36,7 +36,7 @@ Integrating EcoLogits with your applications does not alter the standard outputs
     from openai import OpenAI
     
     # Initialize EcoLogits
-    EcoLogits.init()
+    EcoLogits.init(providers=["openai"])
     
     client = OpenAI(api_key="<OPENAI_API_KEY>")
     
@@ -59,7 +59,7 @@ Integrating EcoLogits with your applications does not alter the standard outputs
     from openai import AsyncOpenAI
     
     # Initialize EcoLogits
-    EcoLogits.init()
+    EcoLogits.init(providers=["openai"])
     
     client = AsyncOpenAI(api_key="<OPENAI_API_KEY>")
     
@@ -89,7 +89,7 @@ Integrating EcoLogits with your applications does not alter the standard outputs
     from openai import OpenAI
     
     # Initialize EcoLogits
-    EcoLogits.init()
+    EcoLogits.init(providers=["openai"])
     
     client = OpenAI(api_key="<OPENAI_API_KEY>")
     
@@ -112,7 +112,7 @@ Integrating EcoLogits with your applications does not alter the standard outputs
     from openai import AsyncOpenAI
     
     # Initialize EcoLogits
-    EcoLogits.init()
+    EcoLogits.init(providers=["openai"])
     
     client = AsyncOpenAI(api_key="<OPENAI_API_KEY>")
     
@@ -144,7 +144,7 @@ from ecologits import EcoLogits
 from openai import AzureOpenAI
 
 # Initialize EcoLogits
-EcoLogits.init()
+EcoLogits.init(providers=["openai"])
 
 client = AzureOpenAI(
     azure_endpoint = os.getenv("AZURE_OPENAI_ENDPOINT"), 

--- a/ecologits/_ecologits.py
+++ b/ecologits/_ecologits.py
@@ -1,5 +1,6 @@
 import importlib.metadata
 import importlib.util
+import warnings
 from dataclasses import dataclass, field
 from typing import Optional, Union
 
@@ -132,9 +133,13 @@ class EcoLogits:
         if isinstance(providers, str):
             providers = [providers]
         if providers is None:
-            logger.warning("Initializing EcoLogits without defining providers will soon no longer be supported. For "
-                           "example with OpenAI, you should use `EcoLogits.init_openai()` or "
-                           "`EcoLogits.init(providers=['openai'])` instead.")
+            warnings.warn(
+                "Initializing EcoLogits without defining providers will soon no longer be supported. For example "
+                "with OpenAI, you should use `EcoLogits.init(providers=['openai'])` instead.",
+                DeprecationWarning,
+                stacklevel=2
+            )
+
             providers = list(_INSTRUMENTS.keys())
 
         init_instruments(providers)

--- a/ecologits/_ecologits.py
+++ b/ecologits/_ecologits.py
@@ -88,16 +88,13 @@ class EcoLogits:
     """
     EcoLogits instrumentor to initialize function patching for each provider.
 
-    By default, the initialization will be done on all available and compatible providers that are supported by the
-    library.
-
     Examples:
         EcoLogits initialization example with OpenAI.
         ```python
         from ecologits import EcoLogits
         from openai import OpenAI
 
-        EcoLogits.init()
+        EcoLogits.init(providers=["openai"])
 
         client = OpenAI(api_key="<OPENAI_API_KEY>")
         response = client.chat.completions.create(
@@ -129,12 +126,15 @@ class EcoLogits:
         Initialization static method. Will attempt to initialize all providers by default.
 
         Args:
-            providers: list of providers to initialize (all providers by default).
+            providers: list of providers to initialize (must select at least one provider).
             electricity_mix_zone: ISO 3166-1 alpha-3 code of the electricity mix zone (WOR by default).
         """
         if isinstance(providers, str):
             providers = [providers]
         if providers is None:
+            logger.warning("Initializing EcoLogits without defining providers will soon no longer be supported. For "
+                           "example with OpenAI, you should use `EcoLogits.init_openai()` or "
+                           "`EcoLogits.init(providers=['openai'])` instead.")
             providers = list(_INSTRUMENTS.keys())
 
         init_instruments(providers)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -39,4 +39,12 @@ def vcr_config():
 
 @pytest.fixture(scope="session")
 def tracer_init():
-    EcoLogits.init()
+    EcoLogits.init(providers=[
+        "anthropic",
+        "cohere",
+        "google",
+        "huggingface_hub",
+        "litellm",
+        "mistralai",
+        "openai"
+    ])

--- a/tests/test_tracer.py
+++ b/tests/test_tracer.py
@@ -7,7 +7,7 @@ from anthropic import Anthropic
 
 @pytest.mark.vcr
 def test_double_init(tracer_init):
-    EcoLogits.init() # second init
+    EcoLogits.init(providers="openai") # second init
     openai_client = OpenAI()
     openai_response = openai_client.chat.completions.create(
         model="gpt-3.5-turbo",
@@ -59,14 +59,14 @@ def test_init_with_different_providers():
 @pytest.mark.vcr
 def test_init_with_different_mixes():
     seed = 0 # Define seed for having the same answers
-    EcoLogits.init() # World's mix
+    EcoLogits.init(providers="openai") # World's mix
     openai_client = OpenAI()
     openai_response_world = openai_client.chat.completions.create(
         model="gpt-3.5-turbo",
         messages=[{"role": "user", "content": "Hello World!"}], 
         seed=seed,
     )
-    EcoLogits.init(electricity_mix_zone="FRA") # Switch to France's mix
+    EcoLogits.init(providers="openai", electricity_mix_zone="FRA") # Switch to France's mix
     openai_response_france = openai_client.chat.completions.create(
         model="gpt-3.5-turbo",
         messages=[{"role": "user", "content": "Hello World!"}], 


### PR DESCRIPTION
Initializing with `init()` without adding `providers` will yield a deprecation warning, as it will no longer be an optional parameter. 

```python
from ecologits import EcoLogits

EcoLogits.init() # displays a deprecation warning

Ecologits.init(providers="openai") # ok
Ecologits.init(providers=["openai", "anthropic"]) # ok
```

---

Also, new initialization methods for each provider **will have to wait**. We need to have a better management of the configuration for each provider to avoid confusions. See example below:

```python
from ecologits import EcoLogits

# Switch from default (WOR) to USA
EcoLogits.init_openai(electricity_mix_zone="USA")
# Switch from USA to FRA
Ecologits.init_mistralai(electricity_mix_zone="FRA")
```

We need to store configuration for each provider in that case; otherwise, it is just confusing.