### PR TITLE
feat(models): add GPT-OSS models

### DIFF
--- a/ecologits/data/models.json
+++ b/ecologits/data/models.json
@@ -1,5 +1,6 @@
 {
     "aliases": [
+        
         {
             "type": "alias",
             "provider": "openai",
@@ -5312,6 +5313,42 @@
             ],
             "sources": [
                 "https://platform.openai.com/docs/models#o3-mini"
+            ]
+        },
+        {
+            "type": "model",
+            "provider": "huggingface_hub",
+            "name": "openai/gpt-oss-120b",
+            "architecture": {
+                "type": "moe",
+                "parameters": {
+                    "total": 116.8,
+                    "active": 5.1
+                }
+            },
+            "warnings": null,
+            "sources": [
+                "https://huggingface.co/openai/gpt-oss-120b",
+                "https://platform.openai.com/docs/models/gpt-oss-120b",
+                "https://cdn.openai.com/pdf/419b6906-9da6-406c-a19d-1bb078ac7637/oai_gpt-oss_model_card.pdf"
+            ]
+        },
+        {
+            "type": "model",
+            "provider": "huggingface_hub",
+            "name": "openai/gpt-oss-20b",
+            "architecture": {
+                "type": "moe",
+                "parameters": {
+                    "total": 20.9,
+                    "active": 3.6
+                }
+            },
+            "warnings": null,
+            "sources": [
+                "https://huggingface.co/openai/gpt-oss-20b",
+                "https://platform.openai.com/docs/models/gpt-oss-20b",
+                "https://cdn.openai.com/pdf/419b6906-9da6-406c-a19d-1bb078ac7637/oai_gpt-oss_model_card.pdf"
             ]
         }
     ]


### PR DESCRIPTION
Added two new OpenAI GPT-OSS models:
- GPT-OSS-120B & 20B

## Problems I had:
Both models have different total parameter number from hugging face to the "release paper". I used the paper one, maybe not the right one?

## Sources: 
### Model 120B
- [Hugging Face Model Card (120B)](https://huggingface.co/openai/gpt-oss-120b)
- [Openai model doc](https://platform.openai.com/docs/models/gpt-oss-120b)
- [Release paper](https://cdn.openai.com/pdf/419b6906-9da6-406c-a19d-1bb078ac7637/oai_gpt-oss_model_card.pdf)

### Model 20B
- [Hugging Face Model Card](https://huggingface.co/openai/gpt-oss-20b)
- [Openai model doc](https://platform.openai.com/docs/models/gpt-oss-20b)
- [Release paper](https://cdn.openai.com/pdf/419b6906-9da6-406c-a19d-1bb078ac7637/oai_gpt-oss_model_card.pdf)

I wanted to add GPT-5, but i don't know how to find the parameters for such an undocumented model...

I'm new to this, happy to learn ;)