### PR TITLE
Fix typo in main page

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -76,7 +76,7 @@ Below are simple examples demonstrating how to use LLM models with **EcoLogits**
     from openai import OpenAI
 
     # Initialize EcoLogits
-    EcoLogits.init(provider=["openai"])
+    EcoLogits.init(providers=["openai"])
 
     client = OpenAI(api_key="<OPENAI_API_KEY>")
 
@@ -115,7 +115,7 @@ Below are simple examples demonstrating how to use LLM models with **EcoLogits**
     from anthropic import Anthropic
     
     # Initialize EcoLogits
-    EcoLogits.init(provider=["anthropic"])
+    EcoLogits.init(providers=["anthropic"])
     
     client = Anthropic(api_key="<ANTHROPIC_API_KEY>")
     
@@ -153,7 +153,7 @@ Below are simple examples demonstrating how to use LLM models with **EcoLogits**
     from huggingface_hub import InferenceClient
     
     # Initialize EcoLogits
-    EcoLogits.init(provider=["huggingface_hub"])
+    EcoLogits.init(providers=["huggingface_hub"])
     
     client = InferenceClient(model="meta-llama/Meta-Llama-3.1-8B")
     response = client.chat_completion( # (1)!


### PR DESCRIPTION
Added "s" to "providers" parameter for Ecologits.init()

Before:
`EcoLogits.init(provider❌=["XXX"])`

Now:
`EcoLogits.init(providers✅=["XXX"])`